### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -18,6 +18,9 @@ on:
       - '.github/workflows/terraform-ci.yml'
       - 'readme.md'
 
+permissions:
+  contents: read
+
 concurrency:
   group: terraform-ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/andrewcrosher/ajc_tf/security/code-scanning/1](https://github.com/andrewcrosher/ajc_tf/security/code-scanning/1)

To fix the problem, explicitly declare the `permissions` for the workflow or the specific job so that the `GITHUB_TOKEN` is limited to the minimum needed. This workflow only reads repository contents (via `actions/checkout`) and runs Terraform/TFLint locally without modifying GitHub resources, so `contents: read` is sufficient.

The best, non-disruptive fix is to add a workflow-level `permissions` block just after the `on:` block (lines 3–19) so it applies to all jobs, including `validate`. Concretely:

- In `.github/workflows/terraform-ci.yml`, insert:

```yaml
permissions:
  contents: read
```

right after the triggers (`on:` section) and before `concurrency:` at line 21. No other changes, imports, or new methods are needed. Existing functionality remains unchanged; only the scope of the `GITHUB_TOKEN` is reduced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
